### PR TITLE
Update the !ascii 'I'

### DIFF
--- a/Ascii.hs
+++ b/Ascii.hs
@@ -57,7 +57,7 @@ toAscii 'g' = [ " __ "
 toAscii 'h' = [ "    "
               , "|_| "
               , "| | "]
-toAscii 'i' = [ " . "
+toAscii 'i' = [ "   "
               , " | "
               , " | "]
 toAscii 'j' = [ " .  "


### PR DESCRIPTION
It was: 

```
. 
| 
| 
```

The new version is:  

```
| 
| 
```

This change was made because both MrTijn and appelknakker thought it looked better.
