### PR TITLE
Add systemd service file

### DIFF
--- a/btjchm.service
+++ b/btjchm.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/opt/btjchm/
-ExecStart=/bin/sh /opt/btjchm/btjchm.sh
+ExecStart=/opt/btjchm/dist/build/btjchm/btjchm
 Restart=on-failure
 User=btjchm
 

--- a/btjchm.service
+++ b/btjchm.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=btjchm irc bot service
+Documentation=https://github.com/jchmrt/btjchm
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/btjchm/
+ExecStart=/bin/sh /opt/btjchm/btjchm.sh
+Restart=on-failure
+User=btjchm
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Using this systemd service file, btjchm can be run as a system service. It automatically restarts after a failure.

Installation of the systemd service file is done by copying or linking it into the `/etc/systemd/system` folder. It assumes that btjchm is installed in `/opt/btjchm`.